### PR TITLE
Add security policy and incident response docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied on `master`.
+
+| Version | Supported |
+| --- | --- |
+| `master` | Yes |
+| Latest tagged release | Best effort |
+| Older releases | No |
+
+If a fix is shipped in a release, assume older releases remain vulnerable unless explicitly noted otherwise.
+
+## Reporting A Vulnerability
+
+Do not open a public GitHub issue for a suspected vulnerability.
+
+Report it privately to `bee@skerritt.blog` with a subject like `[ciphey security] <short summary>`.
+
+If the GitHub UI shows a `Report a vulnerability` option for this repository, you can use that private reporting flow instead of email.
+
+Include:
+
+- affected version, commit, or branch
+- operating system and how you installed `ciphey`
+- a short impact statement
+- reproduction steps or a proof of concept
+- whether the issue requires local access, crafted input, or user interaction
+
+Plain text email is acceptable. If you need a different reporting channel, ask in the initial email.
+
+## What To Expect
+
+Maintainers will aim to:
+
+- acknowledge the report within 72 hours
+- confirm whether the issue is in scope
+- share status updates while a fix is being prepared
+- credit the reporter after disclosure, if requested
+
+Please allow time for a fix before public disclosure.
+
+## Related Security Documents
+
+- Incident response process: [docs/incident_response.md](docs/incident_response.md)
+- Project threat model: [docs/threat_model.md](docs/threat_model.md)
+
+## Scope Notes
+
+Issues that are especially relevant for this project include:
+
+- crashes, hangs, or resource-exhaustion bugs triggered by untrusted input
+- unsafe handling of local files passed through the CLI
+- data exposure involving `~/.ciphey/config.toml`, `~/.ciphey/database.sqlite`, or model files under `~/.ciphey/models/`
+- problems in the optional enhanced-detection setup flow, including token handling during model download
+- supply-chain issues in release artifacts or dependencies that materially affect users of `ciphey`
+
+## User Data And Secrets
+
+Current repository behavior that matters for security review:
+
+- `ciphey` stores cache and human-review data in a local SQLite database at `~/.ciphey/database.sqlite`.
+- Configuration is stored locally at `~/.ciphey/config.toml`.
+- The first-run enhanced-detection flow prompts for a Hugging Face token and states that the token is used for model download and not stored on disk.
+
+If you report an issue, avoid sending real secrets or private datasets unless they are necessary to reproduce the problem.

--- a/docs/incident_response.md
+++ b/docs/incident_response.md
@@ -1,0 +1,74 @@
+# Incident Response Plan
+
+This document defines the maintainer workflow for handling a suspected security incident or vulnerability in `ciphey`.
+
+## Scope
+
+This plan covers:
+
+- vulnerabilities reported through email or GitHub private vulnerability reporting
+- security incidents affecting released code, release artifacts, workflows, or repository secrets
+- security regressions in local file handling, token handling, SQLite persistence, plaintext detection, and decoder execution
+
+## Severity Levels
+
+- `SEV-1`: active exploitation, credential compromise, release compromise, or a vulnerability that can expose sensitive data or execute code without a reasonable workaround
+- `SEV-2`: denial of service, significant local data exposure, or a vulnerability with meaningful impact but limited exploitability
+- `SEV-3`: defense-in-depth gaps, low-impact leaks, or issues that need a fix but do not create immediate user risk
+
+## Response Targets
+
+- Acknowledge a private report within 72 hours.
+- Classify initial severity as soon as the report is reproducible or well-supported.
+- For `SEV-1`, provide reporter updates at least every 24 hours while containment or a fix is in progress.
+- For `SEV-2` and `SEV-3`, provide reporter updates when triage or remediation status materially changes.
+
+## Workflow
+
+### 1. Intake
+
+- Keep reports private.
+- Capture the affected version, commit, impact, and reproduction details.
+- Avoid requesting real secrets unless they are necessary to validate the issue.
+
+### 2. Triage
+
+- Confirm whether the issue is in scope.
+- Reproduce with the smallest local test case possible.
+- Identify whether the issue affects released artifacts, only `master`, or only unreleased changes.
+
+### 3. Containment
+
+Use the smallest effective containment step first:
+
+- pause or restrict vulnerable release activity
+- disable or patch a vulnerable workflow
+- revoke and rotate exposed credentials or tokens
+- publish a temporary mitigation note when a fix will take longer than expected
+
+### 4. Remediation
+
+- land the smallest safe fix that closes the issue without silently extending timeout or trust boundaries
+- add focused regression coverage near the affected component
+- update `SECURITY.md` when reporting behavior or supported channels change
+
+### 5. Release And Disclosure
+
+- prepare a release or other user-facing remediation path
+- coordinate disclosure timing with the reporter when possible
+- use a GitHub security advisory or other private coordination channel until a fix is ready
+- publish clear upgrade or mitigation guidance once disclosure is appropriate
+
+### 6. Post-Incident Review
+
+After remediation:
+
+- document root cause and trigger conditions
+- record what detection or review step failed to catch the issue earlier
+- decide whether tests, benchmarks, review checklists, or release controls need to change
+
+## Evidence Handling
+
+- Keep proof-of-concept material private until disclosure.
+- Redact secrets, tokens, local file contents, and personal data from shared logs.
+- Prefer minimal reproductions over full user datasets.

--- a/docs/threat_model.md
+++ b/docs/threat_model.md
@@ -1,0 +1,99 @@
+# Threat Model
+
+This document outlines the main trust boundaries, assets, and security assumptions for `ciphey`.
+
+## System Overview
+
+`ciphey` is a local decoding tool with a thin CLI over a library-first core. Users provide ciphertext, files, configuration, and optional model-download credentials. The search pipeline runs decoders and checkers against attacker-controlled input and stores some local state under `~/.ciphey`.
+
+## Security Goals
+
+- protect local secrets and sensitive user data
+- avoid unsafe handling of attacker-controlled input
+- preserve integrity of release artifacts and repository automation
+- keep resource usage bounded enough that hostile input does not bypass expected timeout behavior
+
+## Key Assets
+
+- local files passed through `--file`
+- `~/.ciphey/config.toml`
+- `~/.ciphey/database.sqlite`
+- optional model files under `~/.ciphey/models/`
+- Hugging Face or other download credentials used during first-run setup
+- release artifacts, workflow definitions, and dependency metadata
+
+## Trust Boundaries
+
+- CLI arguments, stdin, and file contents are untrusted input.
+- Decoder and checker execution must treat transformed candidate strings as untrusted.
+- The first-run model download flow crosses a trust boundary into third-party services.
+- SQLite-backed persistence is trusted only as local state owned by the current user, not as authoritative truth from a trusted server.
+- GitHub workflows, release automation, and repository settings form the supply-chain boundary for published artifacts.
+
+## Primary Threats
+
+### Crafted Input Causes Resource Exhaustion
+
+Attackers can supply inputs that trigger excessive search branching, expensive checker behavior, or timeout regressions.
+
+Mitigations:
+
+- preserve timeout behavior as part of the public contract
+- keep search and checker changes covered by targeted tests and benches
+- prefer bounded or clearly costed operations when handling candidate plaintext
+
+### Unsafe Local File Handling
+
+The `--file` path and file contents may be attacker-controlled or unexpectedly sensitive.
+
+Mitigations:
+
+- keep file access explicit and local to user-requested paths
+- treat parsing and decoding failures as normal input errors, not exceptional trust signals
+- review changes in file-handling paths as security-sensitive
+
+### Token Or Secret Exposure During First-Run Setup
+
+The enhanced-detection setup flow may involve user credentials for model download.
+
+Mitigations:
+
+- do not log or persist tokens unnecessarily
+- keep credential handling private to the minimum code path required for model download
+- document the expected handling so regressions are easy to spot in review
+
+### Local Persistence Exposure Or Poisoning
+
+Configuration, cache, and human-review data live on disk and may influence later runs.
+
+Mitigations:
+
+- keep storage behavior explicit and predictable
+- use test helpers instead of the real user database in tests
+- review SQLite changes for injection, corruption, and privacy risks
+
+### False Positives Reveal Sensitive Material
+
+Plaintext-identification logic can classify secrets, credentials, or unrelated structured data as meaningful plaintext.
+
+Mitigations:
+
+- validate checker changes with representative encoded and plaintext examples
+- bias toward explainable detection behavior over opaque heuristics when risk is unclear
+- treat secret-like output as a security consideration during checker tuning
+
+### Supply-Chain Or Automation Compromise
+
+Compromised dependencies, workflows, or release automation can affect published artifacts and contributors.
+
+Mitigations:
+
+- protect the default branch
+- use Dependabot, code scanning, and secret scanning
+- prefer reviewed changes over direct pushes to release-critical code paths
+
+## Assumptions And Out Of Scope
+
+- A fully compromised user workstation is out of scope.
+- Network threats are mostly limited to optional model download or dependency/release workflows.
+- `ciphey` is a local analysis tool, not a sandbox for safely executing untrusted code.


### PR DESCRIPTION
## Summary
- add a SECURITY.md policy for private vulnerability reporting
- add an incident response plan
- add a project threat model document

## Notes
- direct pushes to master are blocked by branch protection, so this is submitted through a PR
- GitHub repo security settings were enabled separately with gh before this change