### PR TITLE
Tune Dependabot Cargo update cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,15 @@ updates:
   - package-ecosystem: "cargo" 
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      cargo-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3


### PR DESCRIPTION
## Summary
- switch Cargo Dependabot updates from daily to weekly
- group minor and patch Cargo updates into one PR
- add release cooldowns for major, minor, and patch updates

## Testing
- Parsed `.github/dependabot.yml` locally with Python YAML parser
