### PR TITLE
fix(brainfuck): bound interpreter execution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "rand 0.8.6",
- "rand_distr 0.4.3",
+ "rand_distr",
  "rayon",
  "safetensors 0.4.5",
  "thiserror 1.0.69",
@@ -522,17 +522,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -619,7 +608,7 @@ dependencies = [
  "num",
  "once_cell",
  "proc-macro2",
- "rand 0.10.2",
+ "rand 0.8.6",
  "rayon",
  "regex",
  "rpassword",
@@ -818,15 +807,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,7 +994,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -1822,7 +1802,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -1957,17 +1936,16 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.7.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
 dependencies = [
  "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.4",
- "rand_distr 0.5.1",
- "zerocopy",
+ "rand 0.8.6",
+ "rand_distr",
 ]
 
 [[package]]
@@ -3597,17 +3575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
-dependencies = [
- "chacha20",
- "getrandom 0.4.1",
- "rand_core 0.10.1",
-]
-
-[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3646,12 +3613,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
-
-[[package]]
 name = "rand_distr"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,16 +3620,6 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.6",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
-dependencies = [
- "num-traits",
- "rand 0.9.4",
 ]
 
 [[package]]
@@ -4335,7 +4286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "digest",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,7 @@ dependencies = [
 
 [[package]]
 name = "ciphey"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ansi_term",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ serial_test = "4.0.1"
 text_io = "0.1.13"
 toml = "1.1.2"
 uuid = "1.23.3"
-rand = "0.10"  # Required for candle-core compatibility
-half = "=2.7.1"  # Forced for compatibility with candle-core
+rand = "0.8"  # Required for candle-core compatibility
+half = "=2.3.1"  # Required for candle-core compatibility
 
 # Dependencies used for decoding
 base64 = "0.23.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ciphey"
 repository = "https://github.com/bee-san/ciphey"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 description = "Automated decoding tool, Ciphey but in Rust"
 license = "MIT"

--- a/src/decoders/brainfuck_interpreter.rs
+++ b/src/decoders/brainfuck_interpreter.rs
@@ -11,6 +11,13 @@ use super::interface::Decoder;
 use brainfuck_exe::Brainfuck;
 use log::{debug, trace};
 
+/// Upper bound on the number of Brainfuck instructions the interpreter may execute.
+///
+/// Brainfuck is Turing-complete, so an untrusted program may never terminate.
+/// One million instructions is far above the valid programs in this decoder's
+/// test corpus while bounding malicious execution and output growth.
+const BRAINFUCK_INSTRUCTION_LIMIT: usize = 1_000_000;
+
 /// The Brainfuck interpreter, call:
 /// `let brainfuck_interpreter = Decoder::<BrainfuckInterpreter>::new()` to create a new instance
 /// And then call:
@@ -62,7 +69,11 @@ impl Crack for Decoder<BrainfuckInterpreter> {
         }
 
         let mut buf = vec![];
-        match Brainfuck::new(text).with_output_ref(&mut buf).execute() {
+        match Brainfuck::new(text)
+            .with_instructions_limit(BRAINFUCK_INSTRUCTION_LIMIT)
+            .with_output_ref(&mut buf)
+            .execute()
+        {
             Ok(_) => {
                 let decoded_text = String::from_utf8(buf).unwrap_or_default();
                 let checker_result = checker.check(&decoded_text);
@@ -217,6 +228,21 @@ mod tests {
             .crack("+-<>,.[]", &get_athena_checker())
             .unencrypted_text;
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn brainfuck_infinite_loop_is_bounded() {
+        // Cell 0 = 20 and is never decremented inside `[.....]`, so the loop never exits.
+        // The instruction limit must turn this into a failed decode instead of a hang.
+        let brainfuck_interpreter = Decoder::<BrainfuckInterpreter>::new();
+        let bomb = "++++++++++++++++++++[.....].";
+        let result = brainfuck_interpreter
+            .crack(bomb, &get_athena_checker())
+            .unencrypted_text;
+        assert!(
+            result.is_none(),
+            "infinite-loop brainfuck must be rejected, not run forever"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- cap Brainfuck execution at 1,000,000 instructions
- reject non-terminating programs through the existing decoder error path
- add a regression test and prepare the patched 0.12.1 release
- restore the established `rand 0.8` / `half 2.3.1` pins required by `candle-core 0.3.3` after later Dependabot updates broke all CI builds

## Validation
- `cargo fmt --all -- --check`
- isolated `brainfuck-exe 0.2.4` harness: 4/4 tests pass
- valid Hello World and long Lorem corpus programs remain decodable
- supplied non-terminating CPU/output programs return `MaxInstructionsExceeded(1000000)`
- the pre-fix call shape remained hung until killed after 3 seconds
- dependency graph now unifies `candle-core`, `half`, and `rand_distr` on `rand 0.8.6`; incompatible `half 2.7.1`, `rand 0.10.2`, and `rand_distr 0.5.1` are absent

The PR’s GitHub Actions provide the full cross-platform repository gate.