### PR TITLE
fix(ci): recover release builds on supported runners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,12 @@
 
 version: 2
 updates:
-  - package-ecosystem: "cargo" 
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo"
+    directory: "/"
     schedule:
       interval: "daily"
+    # candle-core 0.3.3 requires the rand 0.8 / half 2.3 compatibility line.
+    # Later versions compile with incompatible rand traits and break every build.
+    ignore:
+      - dependency-name: "rand"
+      - dependency-name: "half"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,4 +13,6 @@ updates:
     # Later versions compile with incompatible rand traits and break every build.
     ignore:
       - dependency-name: "rand"
+        versions: [">= 0.9"]
       - dependency-name: "half"
+        versions: [">= 2.4"]

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,9 @@
 name: Dependabot Auto-merge
-on: pull_request
+
+on:
+  workflow_run:
+    workflows: ["Test"]
+    types: [completed]
 
 permissions:
   contents: write
@@ -7,11 +11,19 @@ permissions:
 
 jobs:
   dependabot:
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
-      - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Merge the tested Dependabot pull request
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          EXPECTED_HEAD: ${{ github.event.workflow_run.head_sha }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          test -n "$PR_NUMBER"
+          test "$(gh pr view "$PR_NUMBER" --json author --jq '.author.login')" = "dependabot"
+          gh pr merge "$PR_NUMBER" --merge --match-head-commit "$EXPECTED_HEAD"

--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -3,6 +3,12 @@ name: Release Builds
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing GitHub release tag to build and upload
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -11,107 +17,70 @@ jobs:
   build:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.release.tag_name }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          # Linux x86_64
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             target: x86_64-unknown-linux-gnu
             artifact_name: ciphey
-            asset_name: ciphey-linux-x86_64
-
-          # macOS x86_64
-          - os: macos-11
+            asset_name: ciphey-linux-x86_64.tar.gz
+            archive: tar
+          - os: macos-15-intel
             target: x86_64-apple-darwin
             artifact_name: ciphey
-            asset_name: ciphey-macos-x86_64
-
-          # macOS ARM64
-          - os: macos-11
+            asset_name: ciphey-macos-x86_64.tar.gz
+            archive: tar
+          - os: macos-15
             target: aarch64-apple-darwin
             artifact_name: ciphey
-            asset_name: ciphey-macos-aarch64
-
-          # Windows x86_64
-          - os: windows-2019
+            asset_name: ciphey-macos-aarch64.tar.gz
+            archive: tar
+          - os: windows-2022
             target: x86_64-pc-windows-msvc
             artifact_name: ciphey.exe
-            asset_name: ciphey-windows-x86_64.exe
+            asset_name: ciphey-windows-x86_64.zip
+            archive: zip
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
+      - name: Checkout release tag
+        uses: actions/checkout@v4
         with:
+          ref: ${{ env.RELEASE_TAG }}
           submodules: recursive
 
-      - name: Setup Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          target: ${{ matrix.target }}
-          override: true
-
-      - name: Cache cargo registry
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo index
-        uses: actions/cache@v3
-        with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Cache cargo build
-        uses: actions/cache@v3
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-target-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
 
       - name: Build release binary
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --target ${{ matrix.target }}
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
+        run: cargo build --locked --release --target ${{ matrix.target }}
 
-      - name: Strip binary (Linux and macOS)
-        if: matrix.os != 'windows-2019'
+      - name: Strip Unix binary
+        if: matrix.archive == 'tar'
         run: strip target/${{ matrix.target }}/release/${{ matrix.artifact_name }}
 
-      - name: Create tarball (Linux and macOS)
-        if: matrix.os != 'windows-2019'
+      - name: Package Unix binary
+        if: matrix.archive == 'tar'
+        shell: bash
         run: |
-          cd target/${{ matrix.target }}/release
-          tar czf ${{ matrix.asset_name }}.tar.gz ${{ matrix.artifact_name }}
-          mv ${{ matrix.asset_name }}.tar.gz ../../../
+          tar -C "target/${{ matrix.target }}/release" -czf "${{ matrix.asset_name }}" "${{ matrix.artifact_name }}"
+          shasum -a 256 "${{ matrix.asset_name }}" > "${{ matrix.asset_name }}.sha256"
 
-      - name: Create zip (Windows)
-        if: matrix.os == 'windows-2019'
+      - name: Package Windows binary
+        if: matrix.archive == 'zip'
         shell: pwsh
         run: |
-          Compress-Archive -Path target/${{ matrix.target }}/release/${{ matrix.artifact_name }} -DestinationPath ${{ matrix.asset_name }}.zip
+          $asset = "${{ matrix.asset_name }}"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.artifact_name }}" -DestinationPath $asset
+          $hash = (Get-FileHash -Algorithm SHA256 $asset).Hash.ToLower()
+          "$hash  $asset" | Out-File -Encoding ascii "$asset.sha256"
 
-      - name: Upload release asset (Linux and macOS)
-        if: matrix.os != 'windows-2019'
-        uses: actions/upload-release-asset@v1
+      - name: Upload release assets
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ matrix.asset_name }}.tar.gz
-          asset_name: ${{ matrix.asset_name }}.tar.gz
-          asset_content_type: application/gzip
-
-      - name: Upload release asset (Windows)
-        if: matrix.os == 'windows-2019'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ./${{ matrix.asset_name }}.zip
-          asset_name: ${{ matrix.asset_name }}.zip
-          asset_content_type: application/zip
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: gh release upload "$RELEASE_TAG" "${{ matrix.asset_name }}" "${{ matrix.asset_name }}.sha256" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install cargo-dist
@@ -89,16 +89,16 @@ jobs:
       matrix:
         # For these target platforms
         include:
-        - os: "macos-11"
+        - os: "macos-15"
           dist-args: "--artifacts=local --target=aarch64-apple-darwin"
           install-dist: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.1.0/cargo-dist-installer.sh | sh"
-        - os: "macos-11"
+        - os: "macos-15-intel"
           dist-args: "--artifacts=local --target=x86_64-apple-darwin"
           install-dist: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.1.0/cargo-dist-installer.sh | sh"
-        - os: "windows-2019"
+        - os: "windows-2022"
           dist-args: "--artifacts=local --target=x86_64-pc-windows-msvc"
           install-dist: "irm  https://github.com/axodotdev/cargo-dist/releases/download/v0.1.0/cargo-dist-installer.ps1 | iex"
-        - os: "ubuntu-20.04"
+        - os: "ubuntu-22.04"
           dist-args: "--artifacts=local --target=x86_64-unknown-linux-gnu"
           install-dist: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.1.0/cargo-dist-installer.sh | sh"
 
@@ -106,7 +106,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install cargo-dist
@@ -126,6 +126,7 @@ jobs:
           jq --raw-output ".artifacts[]?.path | select( . != null )" dist-manifest.json > uploads.txt
           echo "uploading..."
           cat uploads.txt
+          # shellcheck disable=SC2046
           gh release upload ${{ github.ref_name }} $(cat uploads.txt)
           echo "uploaded!"
 
@@ -138,7 +139,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: mark release as non-draft
@@ -150,11 +151,8 @@ jobs:
     needs: publish-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: stable
-            override: true
-      - uses: katyo/publish-crates@v1
-        with:
-            registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - uses: actions/checkout@v4
+      - name: Publish package to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,7 +381,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "rand 0.8.8",
- "rand_distr 0.4.3",
+ "rand_distr",
  "rayon",
  "safetensors 0.4.5",
  "thiserror 1.0.69",
@@ -608,7 +608,7 @@ dependencies = [
  "num",
  "once_cell",
  "proc-macro2",
- "rand 0.9.4",
+ "rand 0.8.8",
  "rayon",
  "regex",
  "rpassword",
@@ -1936,17 +1936,16 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.7.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+checksum = "bc52e53916c08643f1b56ec082790d1e86a32e58dc5268f897f313fbae7b4872"
 dependencies = [
  "bytemuck",
  "cfg-if",
  "crunchy",
  "num-traits",
- "rand 0.9.4",
- "rand_distr 0.5.1",
- "zerocopy",
+ "rand 0.8.8",
+ "rand_distr",
 ]
 
 [[package]]
@@ -3621,16 +3620,6 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
  "rand 0.8.8",
-]
-
-[[package]]
-name = "rand_distr"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
-dependencies = [
- "num-traits",
- "rand 0.9.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,8 +50,8 @@ serial_test = "4.0.1"
 text_io = "0.1.13"
 toml = "1.1.2"
 uuid = "1.23.3"
-rand = "0.9"  # Required for candle-core compatibility
-half = "=2.7.1"  # Required for candle-core compatibility
+rand = "0.8"  # Required for candle-core compatibility
+half = "=2.3.1"  # Required for candle-core compatibility
 
 # Dependencies used for decoding
 base64 = "0.23.0"


### PR DESCRIPTION
## Summary
- move release builds off retired Ubuntu 20.04, macOS 11, and Windows 2019 runner labels
- add a manual tag recovery path that uploads binaries and SHA-256 files to an existing release
- restore the `rand 0.8` / `half 2.3.1` compatibility pins and stop Dependabot from proposing incompatible upgrades
- only merge Dependabot PRs after the full `Test` workflow succeeds
- modernise release checkout/publish steps

## Why
The v0.12.1 binary jobs remained queued for 24 hours and were cancelled without ever receiving runners. Separately, Dependabot immediately auto-merged incompatible `half` and `rand` upgrades despite failing every test job.

## Validation
- `actionlint` passes for all changed workflows
- YAML parsing passes
- `cargo fmt --all -- --check` passes
- dependency graph uses `half 2.3.1` and Ciphey/candle use `rand 0.8`; incompatible `half 2.7.1` and `rand_distr 0.5.1` are absent
- full repository validation is delegated to this PR’s GitHub Actions