### PR TITLE
fix(release): emit portable Windows checksum

### DIFF
--- a/.github/workflows/release-builds.yml
+++ b/.github/workflows/release-builds.yml
@@ -77,7 +77,7 @@ jobs:
           $asset = "${{ matrix.asset_name }}"
           Compress-Archive -Path "target/${{ matrix.target }}/release/${{ matrix.artifact_name }}" -DestinationPath $asset
           $hash = (Get-FileHash -Algorithm SHA256 $asset).Hash.ToLower()
-          "$hash  $asset" | Out-File -Encoding ascii "$asset.sha256"
+          "$hash  $asset" | Set-Content -NoNewline -Encoding ascii "$asset.sha256"
 
       - name: Upload release assets
         env:


### PR DESCRIPTION
## Summary
Use `Set-Content -NoNewline` for the Windows SHA-256 sidecar so Unix checksum tools do not interpret a CRLF carriage return as part of the archive filename.

The already-published `v0.12.1` Windows checksum asset has also been regenerated in portable LF form and verified against the uploaded ZIP.

## Validation
- `actionlint .github/workflows/release-builds.yml`
- `git diff --check`
- downloaded `ciphey-windows-x86_64.zip` passes the corrected `shasum -a 256 -c` sidecar
- `unzip -t` reports no archive errors